### PR TITLE
[FEAT] 행사 생성 페이지 구현

### DIFF
--- a/FE/src/app/(program)/create/loading.tsx
+++ b/FE/src/app/(program)/create/loading.tsx
@@ -1,0 +1,4 @@
+import LoadingSpinner from "@/components/common/LoadingSpinner";
+
+const CreateLoading = () => <LoadingSpinner />;
+export default CreateLoading;

--- a/FE/src/app/(program)/create/page.tsx
+++ b/FE/src/app/(program)/create/page.tsx
@@ -1,8 +1,6 @@
+import ProgramCreateForm from "@/components/programCreate/ProgramCreateForm";
+
 const ProgramCreatePage = () => {
-  return (
-    <div>
-      <h1>Program Create Page</h1>
-    </div>
-  );
+  return <ProgramCreateForm />;
 };
 export default ProgramCreatePage;

--- a/FE/src/app/(program)/create/page.tsx
+++ b/FE/src/app/(program)/create/page.tsx
@@ -1,6 +1,12 @@
+import Title from "@/components/common/Title";
 import ProgramCreateForm from "@/components/programCreate/ProgramCreateForm";
 
 const ProgramCreatePage = () => {
-  return <ProgramCreateForm />;
+  return (
+    <div className="space-y-12">
+      <Title text="행사 생성" />
+      <ProgramCreateForm />
+    </div>
+  );
 };
 export default ProgramCreatePage;

--- a/FE/src/components/common/Button.tsx
+++ b/FE/src/components/common/Button.tsx
@@ -12,15 +12,23 @@ const sizes = {
   lg: "py-3 px-5 rounded-lg min-w-[8rem]",
 };
 
-interface Props {
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   disabled?: boolean;
-  color: keyof typeof colors;
-  size: keyof typeof sizes;
+  color?: keyof typeof colors;
+  size?: keyof typeof sizes;
   children: React.ReactNode;
   className?: string;
 }
 
-const Button = ({ disabled, color, size, children, className }: Props) => {
+const Button = ({
+  disabled,
+  color = "primary",
+  size = "md",
+  children,
+  className,
+  type = "button",
+  onClick = () => {},
+}: ButtonProps) => {
   const btnStyle = classNames(
     "flex justify-center gap-2",
     colors[color],
@@ -29,7 +37,12 @@ const Button = ({ disabled, color, size, children, className }: Props) => {
   );
 
   return (
-    <button disabled={disabled} className={btnStyle}>
+    <button
+      disabled={disabled}
+      className={btnStyle}
+      type={type}
+      onClick={onClick}
+    >
       {children}
     </button>
   );

--- a/FE/src/components/common/Calendar.tsx
+++ b/FE/src/components/common/Calendar.tsx
@@ -1,0 +1,23 @@
+import { DayPicker } from "react-day-picker";
+import "react-day-picker/dist/style.css";
+import "./styles/calendar.styles.css";
+
+interface CalendarProps {
+  date: Date | undefined;
+  handleDateChange: (date: Date | undefined) => void;
+}
+
+const Calendar = ({ date, handleDateChange }: CalendarProps) => {
+  const disabledDays = { before: new Date() };
+
+  return (
+    <DayPicker
+      mode="single"
+      selected={date}
+      onSelect={handleDateChange}
+      disabled={disabledDays}
+      className="absolute left-0 top-[4.5rem] z-10 rounded-md bg-background p-3 shadow-md"
+    />
+  );
+};
+export default Calendar;

--- a/FE/src/components/common/CheckBox.tsx
+++ b/FE/src/components/common/CheckBox.tsx
@@ -1,0 +1,37 @@
+import classNames from "classnames";
+import Image from "next/image";
+
+interface CheckBoxProps {
+  checked: boolean;
+  onClick: () => void;
+  disabled?: boolean;
+}
+
+const CheckBox = ({ checked, onClick, disabled = false }: CheckBoxProps) => {
+  const checkboxClass = classNames(
+    "flex h-6 w-6 items-center justify-center rounded border-2 transition duration-100",
+    checked ? "border-blue-500 bg-blue-500" : "border-gray-20 bg-background",
+    {
+      "cursor-not-allowed opacity-0": disabled,
+    },
+  );
+
+  const handleCheckBoxClick = () => {
+    !disabled && onClick();
+  };
+
+  return (
+    <div onClick={handleCheckBoxClick} className={checkboxClass}>
+      {checked && (
+        <Image
+          src={"/icons/check.svg"}
+          alt="check"
+          width={24}
+          height={24}
+          style={{ width: 24, height: 24 }}
+        />
+      )}
+    </div>
+  );
+};
+export default CheckBox;

--- a/FE/src/components/common/calendar/Calendar.tsx
+++ b/FE/src/components/common/calendar/Calendar.tsx
@@ -1,6 +1,6 @@
 import { DayPicker } from "react-day-picker";
 import "react-day-picker/dist/style.css";
-import "./styles/calendar.styles.css";
+import "./calendar.styles.css";
 
 interface CalendarProps {
   date: Date | undefined;

--- a/FE/src/components/common/calendar/calendar.styles.css
+++ b/FE/src/components/common/calendar/calendar.styles.css
@@ -1,0 +1,12 @@
+.rdp {
+  --rdp-cell-size: 2.5rem;
+  --rdp-accent-color: #ffd803;
+  --rdp-background-color: #fffffe;
+}
+
+.rdp-day_selected,
+.rdp-day_selected:focus-visible,
+.rdp-day_selected:hover {
+  background-color: var(--rdp-accent-color) !important;
+  color: white;
+}

--- a/FE/src/components/common/form/FormBtn.tsx
+++ b/FE/src/components/common/form/FormBtn.tsx
@@ -1,0 +1,18 @@
+import Button from "../Button";
+
+interface FormButtonProps {
+  submitText: string;
+  formReset: () => void;
+}
+
+const FormButton = ({ submitText, formReset = () => {} }: FormButtonProps) => {
+  return (
+    <div className="mt-6 flex w-full justify-end gap-2">
+      <Button type="submit">{submitText}</Button>
+      <Button color="gray" onClick={formReset}>
+        취소
+      </Button>
+    </div>
+  );
+};
+export default FormButton;

--- a/FE/src/components/common/form/FormBtn.tsx
+++ b/FE/src/components/common/form/FormBtn.tsx
@@ -1,11 +1,11 @@
 import Button from "../Button";
 
-interface FormButtonProps {
+interface FormBtnProps {
   submitText: string;
   formReset: () => void;
 }
 
-const FormButton = ({ submitText, formReset = () => {} }: FormButtonProps) => {
+const FormBtn = ({ submitText, formReset = () => {} }: FormBtnProps) => {
   return (
     <div className="mt-6 flex w-full justify-end gap-2">
       <Button type="submit">{submitText}</Button>
@@ -15,4 +15,4 @@ const FormButton = ({ submitText, formReset = () => {} }: FormButtonProps) => {
     </div>
   );
 };
-export default FormButton;
+export default FormBtn;

--- a/FE/src/components/common/form/LabeledInput.tsx
+++ b/FE/src/components/common/form/LabeledInput.tsx
@@ -1,0 +1,36 @@
+interface InputProps extends React.HTMLProps<HTMLInputElement> {
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  prefix?: string;
+}
+
+const LabeledInput = ({
+  id,
+  label,
+  value,
+  onChange,
+  placeholder,
+  type,
+  prefix,
+}: InputProps) => {
+  return (
+    <div className="flex flex-col gap-2">
+      <label htmlFor={id} className="text-sm">
+        {label}
+      </label>
+      <div className="flex w-full gap-1 rounded-md border-[1.5px] border-gray-300 px-3 py-2 focus:border-tertiary-10">
+        {prefix && <span className="whitespace-nowrap">{prefix}</span>}
+        <input
+          id={id}
+          value={value}
+          onChange={onChange}
+          placeholder={placeholder}
+          type={type}
+          autoComplete="off"
+          className="w-full bg-transparent focus:outline-none"
+        />
+      </div>
+    </div>
+  );
+};
+
+export default LabeledInput;

--- a/FE/src/components/common/form/ProgramDate.tsx
+++ b/FE/src/components/common/form/ProgramDate.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import useOutsideRef from "@/hooks/useOutsideRef";
+import { useState } from "react";
+import LabeledInput from "./LabeledInput";
+import FORM_INFO from "@/constants/FORM_INFO";
+import { convertDate } from "@/utils/convert";
+import Calendar from "../Calendar";
+
+interface ProgramDateInputProps {
+  programDate: string;
+  setProgramDate: (date: string) => void;
+}
+
+const ProgramDateInput = ({
+  programDate,
+  setProgramDate,
+}: ProgramDateInputProps) => {
+  const [openCalender, setOpenCalender] = useState<boolean>(false);
+  const calenderRef = useOutsideRef(() => setOpenCalender(false));
+  const [date, setDate] = useState<Date | undefined>(
+    new Date(parseInt(programDate)) || new Date(),
+  );
+
+  const handleDateChange = (date: Date | undefined) => {
+    setDate(date);
+    setProgramDate(
+      date?.getTime().toString() || new Date().getTime().toString(),
+    );
+  };
+
+  return (
+    <div
+      onClick={() => setOpenCalender(true)}
+      className="relative w-full"
+      ref={calenderRef}
+    >
+      <LabeledInput
+        id={FORM_INFO.PROGRAM.DATE.id}
+        type={FORM_INFO.PROGRAM.DATE.type}
+        label={FORM_INFO.PROGRAM.DATE.label}
+        placeholder={FORM_INFO.PROGRAM.DATE.placeholder}
+        value={convertDate(programDate)}
+      />
+      {openCalender && (
+        <Calendar date={date} handleDateChange={handleDateChange} />
+      )}
+    </div>
+  );
+};
+export default ProgramDateInput;

--- a/FE/src/components/common/form/ProgramDate.tsx
+++ b/FE/src/components/common/form/ProgramDate.tsx
@@ -5,17 +5,14 @@ import { useState } from "react";
 import LabeledInput from "./LabeledInput";
 import FORM_INFO from "@/constants/FORM_INFO";
 import { convertDate } from "@/utils/convert";
-import Calendar from "../Calendar";
+import Calendar from "../calendar/Calendar";
 
-interface ProgramDateInputProps {
+interface ProgramDateProps {
   programDate: string;
   setProgramDate: (date: string) => void;
 }
 
-const ProgramDateInput = ({
-  programDate,
-  setProgramDate,
-}: ProgramDateInputProps) => {
+const ProgramDate = ({ programDate, setProgramDate }: ProgramDateProps) => {
   const [openCalender, setOpenCalender] = useState<boolean>(false);
   const calenderRef = useOutsideRef(() => setOpenCalender(false));
   const [date, setDate] = useState<Date | undefined>(
@@ -48,4 +45,4 @@ const ProgramDateInput = ({
     </div>
   );
 };
-export default ProgramDateInput;
+export default ProgramDate;

--- a/FE/src/components/common/form/ProgramDemandCheckBox.tsx
+++ b/FE/src/components/common/form/ProgramDemandCheckBox.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 interface ProgramDemandCheckBoxProps {
   disabled: boolean;
   isDemand: boolean;

--- a/FE/src/components/common/form/ProgramDemandCheckBox.tsx
+++ b/FE/src/components/common/form/ProgramDemandCheckBox.tsx
@@ -3,7 +3,7 @@
 interface ProgramDemandCheckBoxProps {
   disabled: boolean;
   isDemand: boolean;
-  onClick: (v: boolean) => void;
+  onClick: () => void;
 }
 
 const ProgramDemandCheckBox = ({
@@ -21,7 +21,7 @@ const ProgramDemandCheckBox = ({
             type="checkbox"
             className="accent-primary"
             checked={isDemand}
-            onChange={() => onClick(!isDemand)}
+            onChange={onClick}
           />
         </div>
       )}

--- a/FE/src/components/common/form/ProgramDemandCheckBox.tsx
+++ b/FE/src/components/common/form/ProgramDemandCheckBox.tsx
@@ -1,0 +1,29 @@
+interface ProgramDemandCheckBoxProps {
+  disabled: boolean;
+  isDemand: boolean;
+  onClick: (v: boolean) => void;
+}
+
+const ProgramDemandCheckBox = ({
+  disabled,
+  isDemand,
+  onClick,
+}: ProgramDemandCheckBoxProps) => {
+  return (
+    <>
+      {!disabled && (
+        <div className="absolute right-0 top-0 flex gap-2">
+          <label className="text-sm font-bold">수요조사 등록하기</label>
+          {/* TODO: Checkbox 컴포넌트로 변경 */}
+          <input
+            type="checkbox"
+            className="accent-primary"
+            checked={isDemand}
+            onChange={() => onClick(!isDemand)}
+          />
+        </div>
+      )}
+    </>
+  );
+};
+export default ProgramDemandCheckBox;

--- a/FE/src/components/common/form/ProgramForm.tsx
+++ b/FE/src/components/common/form/ProgramForm.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { ProgramCategory } from "@/types/program";
+import Tab from "../tabs/Tab";
+import ProgramDate from "./ProgramDate";
+import ProgramDemandCheckBox from "./ProgramDemandCheckBox";
+import ProgramTitle from "./ProgramTitle";
+import PROGRAM from "@/constants/PROGRAM";
+import { PropsWithChildren } from "react";
+import FormBtn from "./FormBtn";
+import FORM_INFO from "@/constants/FORM_INFO";
+import { FormType } from "@/types/form";
+import MarkdownEditor from "../markdown/MarkdownEditor";
+
+interface ProgramFormProps {
+  formType: FormType;
+}
+
+const ProgramForm = ({
+  children,
+  formType,
+}: PropsWithChildren<ProgramFormProps>) => {
+  const demandDisabled = formType === "edit";
+
+  return (
+    <form className="space-y-6">
+      <ProgramTitle title={"test"} setTitle={() => {}}>
+        <ProgramDemandCheckBox
+          disabled={demandDisabled}
+          isDemand={true}
+          onClick={() => {}}
+        />
+      </ProgramTitle>
+      <div className="flex items-end gap-8">
+        <ProgramDate programDate={"123456789"} setProgramDate={() => {}} />
+        <Tab<ProgramCategory>
+          options={Object.values(PROGRAM.CATEGORY_TAB)}
+          selected={"weekly"}
+          onItemClick={() => {}}
+          size="lg"
+          baseColor="gray"
+          pointColor="yellow"
+          align="line"
+        />
+      </div>
+      <MarkdownEditor
+        id={FORM_INFO.PROGRAM.CONTENT.id}
+        label={FORM_INFO.PROGRAM.CONTENT.label}
+        placeholder={FORM_INFO.PROGRAM.CONTENT.placeholder}
+        value={"test"}
+        onChange={() => {}}
+      />
+      {children}
+      <FormBtn
+        submitText={FORM_INFO.SUBMIT_TEXT[formType]}
+        formReset={() => {}}
+      />
+    </form>
+  );
+};
+
+export default ProgramForm;

--- a/FE/src/components/common/form/ProgramForm.tsx
+++ b/FE/src/components/common/form/ProgramForm.tsx
@@ -11,32 +11,56 @@ import FormBtn from "./FormBtn";
 import FORM_INFO from "@/constants/FORM_INFO";
 import { FormType } from "@/types/form";
 import MarkdownEditor from "../markdown/MarkdownEditor";
+import { ProgramFormData } from "@/hooks/useProgramFormData";
 
 interface ProgramFormProps {
+  formData: ProgramFormData;
   formType: FormType;
 }
 
 const ProgramForm = ({
   children,
+  formData,
   formType,
 }: PropsWithChildren<ProgramFormProps>) => {
-  const demandDisabled = formType === "edit";
+  const {
+    title,
+    setTitle,
+    deadLine,
+    setDeadLine,
+    category,
+    setCategory,
+    type,
+    setType,
+    content,
+    setContent,
+    reset,
+  } = formData;
+  const isDemand = type === "demand";
+  const demandCheckBoxDisabled = formType === "edit";
+
+  const handleChangeType = () => {
+    setType(isDemand ? "notification" : "demand");
+  };
 
   return (
     <form className="space-y-6">
-      <ProgramTitle title={"test"} setTitle={() => {}}>
+      <ProgramTitle title={title} setTitle={(v) => setTitle(v)}>
         <ProgramDemandCheckBox
-          disabled={demandDisabled}
-          isDemand={true}
-          onClick={() => {}}
+          disabled={demandCheckBoxDisabled}
+          isDemand={isDemand}
+          onClick={() => handleChangeType()}
         />
       </ProgramTitle>
       <div className="flex items-end gap-8">
-        <ProgramDate programDate={"123456789"} setProgramDate={() => {}} />
+        <ProgramDate
+          programDate={deadLine}
+          setProgramDate={(v) => setDeadLine(v)}
+        />
         <Tab<ProgramCategory>
           options={Object.values(PROGRAM.CATEGORY_TAB)}
-          selected={"weekly"}
-          onItemClick={() => {}}
+          selected={category}
+          onItemClick={(v) => setCategory(v)}
           size="lg"
           baseColor="gray"
           pointColor="yellow"
@@ -47,14 +71,11 @@ const ProgramForm = ({
         id={FORM_INFO.PROGRAM.CONTENT.id}
         label={FORM_INFO.PROGRAM.CONTENT.label}
         placeholder={FORM_INFO.PROGRAM.CONTENT.placeholder}
-        value={"test"}
-        onChange={() => {}}
+        value={content}
+        onChange={(v) => setContent(v)}
       />
       {children}
-      <FormBtn
-        submitText={FORM_INFO.SUBMIT_TEXT[formType]}
-        formReset={() => {}}
-      />
+      <FormBtn submitText={FORM_INFO.SUBMIT_TEXT[formType]} formReset={reset} />
     </form>
   );
 };

--- a/FE/src/components/common/form/ProgramTitle.tsx
+++ b/FE/src/components/common/form/ProgramTitle.tsx
@@ -1,0 +1,34 @@
+import React, { PropsWithChildren } from "react";
+import LabeledInput from "./LabeledInput";
+import FORM_INFO from "@/constants/FORM_INFO";
+
+interface ProgramTitleProps {
+  title: string;
+  setTitle: (title: string) => void;
+  prefix?: string;
+}
+
+const ProgramTitle = ({
+  title,
+  setTitle,
+  prefix,
+  children,
+}: PropsWithChildren<ProgramTitleProps>) => {
+  return (
+    <div className="relative">
+      {children}
+      <LabeledInput
+        id={FORM_INFO.PROGRAM.TITLE.id}
+        type={FORM_INFO.PROGRAM.TITLE.type}
+        label={FORM_INFO.PROGRAM.TITLE.label}
+        placeholder={FORM_INFO.PROGRAM.TITLE.placeholder}
+        value={title}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+          setTitle(e.target.value)
+        }
+        prefix={prefix}
+      />
+    </div>
+  );
+};
+export default ProgramTitle;

--- a/FE/src/components/common/markdown/MarkdownEditor.tsx
+++ b/FE/src/components/common/markdown/MarkdownEditor.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import "./markdown-editor.styles.css";
+import { useState } from "react";
+import MarkdownViewer from "./MarkdownViewer";
+import { TabOption } from "@/types/tab";
+import Tab from "../tabs/Tab";
+import { handleKeydown } from "@/utils/handleKeydown";
+
+interface MarkdownEditorProps {
+  id: string;
+  value: string;
+  onChange: (value?: string) => void;
+  label: string;
+  placeholder: string;
+}
+type MarkdownViewType = "write" | "preview";
+type MarkdownEditorTabProps = {
+  [key in MarkdownViewType]: TabOption<MarkdownViewType>;
+};
+
+const EDITOR_TAB: MarkdownEditorTabProps = {
+  write: {
+    text: "작성하기",
+    type: "write",
+  },
+  preview: {
+    text: "미리보기",
+    type: "preview",
+  },
+};
+
+const MarkdownEditor = ({
+  id,
+  value,
+  onChange,
+  label,
+  placeholder,
+}: MarkdownEditorProps) => {
+  const [viewType, setViewType] = useState<"write" | "preview">("write");
+
+  return (
+    <div className="flex flex-col gap-2">
+      <label htmlFor={id} className="text-sm">
+        {label}
+      </label>
+      <div className="flex h-fit w-full flex-col gap-2 rounded-md border-2 border-gray-300 bg-gray-10 p-2 transition-transform">
+        <Tab<MarkdownViewType>
+          options={Object.values(EDITOR_TAB)}
+          selected={viewType}
+          onItemClick={(v) => setViewType(v)}
+          size="sm"
+          baseColor="white"
+          pointColor="navy"
+          align="line"
+        />
+        {viewType === "write" ? (
+          <textarea
+            id={id}
+            value={value}
+            onChange={(e) => onChange(e.target.value)}
+            className="scrollbar-none h-[32rem] w-full resize-none overflow-y-scroll bg-background p-4 outline-none"
+            placeholder={placeholder}
+            onKeyDown={handleKeydown}
+          />
+        ) : (
+          <MarkdownViewer
+            value={value}
+            className="scrollbar-none h-[32rem] w-full"
+          />
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default MarkdownEditor;

--- a/FE/src/components/common/memberTable/MemberTable.tsx
+++ b/FE/src/components/common/memberTable/MemberTable.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { ActiveStatusWithAll } from "@/types/member";
+import ACTIVE_STATUS from "@/constants/ACTIVE_STATUS";
+import { FormType } from "@/types/form";
+import Tab from "../tabs/Tab";
+import MemberTableHeader from "./MemberTableHeader";
+import CreateMemberTableItemContainer from "@/components/programCreate/CreateMemberTableItemContainer";
+import EditMemberTableItemContainer from "@/components/programEdit/EditMemberTableItemContainer";
+import { Suspense, useState } from "react";
+
+interface MemberTableProps {
+  formType: FormType;
+  members: Set<number>;
+  setMembers: (members: Set<number>) => void;
+}
+
+const MemberTable = ({ formType, members, setMembers }: MemberTableProps) => {
+  const [selectedActive, setSelectedActive] =
+    useState<ActiveStatusWithAll>("all");
+  return (
+    <div className="space-y-6 pt-10">
+      <Tab<ActiveStatusWithAll>
+        options={Object.values(ACTIVE_STATUS.TAB_WITH_ALL)}
+        selected={selectedActive}
+        onItemClick={(v) => setSelectedActive(v)}
+        size="lg"
+        baseColor="gray"
+        pointColor="teal"
+        align="line"
+      />
+      <div>
+        <MemberTableHeader
+          formType={formType}
+          checked={false}
+          onClickCheckBox={() => {}}
+        />
+        <Suspense fallback={<div>로딩중...</div>}>
+          {formType === "create" ? (
+            <CreateMemberTableItemContainer
+              members={members}
+              setMembers={setMembers}
+              status={selectedActive}
+            />
+          ) : (
+            <EditMemberTableItemContainer />
+          )}
+        </Suspense>
+      </div>
+    </div>
+  );
+};
+
+export default MemberTable;

--- a/FE/src/components/common/memberTable/MemberTableHeader.tsx
+++ b/FE/src/components/common/memberTable/MemberTableHeader.tsx
@@ -1,0 +1,29 @@
+import { FormType } from "@/types/form";
+import CheckBox from "../CheckBox";
+
+interface MemberTableHeaderProps {
+  formType: FormType;
+  checked: boolean;
+  onClickCheckBox: () => void;
+}
+
+const HEADER_TEXT = {
+  create: ["활동 상태", "이름"],
+  edit: ["활동 상태", "이름", "", "출석 상태"],
+};
+
+const MemberTableHeader = ({
+  formType,
+  checked,
+  onClickCheckBox,
+}: MemberTableHeaderProps) => {
+  return (
+    <div className="grid grid-cols-[4.75rem_7rem_7.25rem_1fr_20.5rem] justify-items-center gap-4 border-y-2 border-stroke-10 bg-gray-10 px-10 py-4 font-bold">
+      <CheckBox checked={checked} onClick={() => onClickCheckBox()} />
+      {HEADER_TEXT[formType].map((text: string, index: number) => (
+        <span key={index}>{text}</span>
+      ))}
+    </div>
+  );
+};
+export default MemberTableHeader;

--- a/FE/src/components/programCreate/CreateMemberTableItem.tsx
+++ b/FE/src/components/programCreate/CreateMemberTableItem.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import ACTIVE_STATUS from "@/constants/ACTIVE_STATUS";
+import CheckBox from "../common/CheckBox";
+import { MemberActiveStatusInfoDto } from "@/apis/dtos/member.dto";
+
+interface CreateMemberTableItemProps {
+  data: MemberActiveStatusInfoDto;
+  members: Set<number>;
+  setMembers: (members: Set<number>) => void;
+}
+
+const CreateMemberTableItem = ({
+  data,
+  members,
+  setMembers,
+}: CreateMemberTableItemProps) => {
+  const { memberId, name, activeStatus } = data;
+  const isRelated = members.has(memberId);
+
+  const handleCheckBoxChange = () => {
+    const newMembers = new Set<number>(members);
+    isRelated ? newMembers.delete(memberId) : newMembers.add(memberId);
+    setMembers(newMembers);
+  };
+
+  return (
+    <div className="grid h-20 grid-cols-[4.75rem_7rem_7.25rem_1fr_20.5rem] items-center justify-items-center gap-4 border-b-2 border-stroke-10 bg-background px-10">
+      <CheckBox checked={isRelated} onClick={handleCheckBoxChange} />
+      <span>{ACTIVE_STATUS.TAB[activeStatus].text}</span>
+      <span className="font-bold">{name}</span>
+    </div>
+  );
+};
+export default CreateMemberTableItem;

--- a/FE/src/components/programCreate/CreateMemberTableItemContainer.tsx
+++ b/FE/src/components/programCreate/CreateMemberTableItemContainer.tsx
@@ -1,0 +1,35 @@
+import { useGetMemberByActive } from "@/hooks/query/useMemberQuery";
+import CreateMemberTableItem from "./CreateMemberTableItem";
+import { ActiveStatusWithAll } from "@/types/member";
+
+interface CreateMemberTableItemContainerProps {
+  members: Set<number>;
+  setMembers: (members: Set<number>) => void;
+  status: ActiveStatusWithAll;
+}
+
+const CreateMemberTableItemContainer = ({
+  members,
+  setMembers,
+  status,
+}: CreateMemberTableItemContainerProps) => {
+  const { data: memberList, isLoading, isError } = useGetMemberByActive(status);
+
+  if (isLoading) return <div>로딩중...</div>;
+  if (isError) return <div>에러가 발생했습니다.</div>;
+
+  return (
+    <>
+      {memberList.map((member) => (
+        <CreateMemberTableItem
+          key={member.memberId}
+          data={member}
+          members={members}
+          setMembers={setMembers}
+        />
+      ))}
+    </>
+  );
+};
+
+export default CreateMemberTableItemContainer;

--- a/FE/src/components/programCreate/ProgramCreateForm.tsx
+++ b/FE/src/components/programCreate/ProgramCreateForm.tsx
@@ -1,6 +1,20 @@
+"use client";
+
 import ProgramForm from "../common/form/ProgramForm";
+import MemberTable from "../common/memberTable/MemberTable";
+import useProgramFormData from "@/hooks/useProgramFormData";
 
 const ProgramCreateForm = () => {
-  return <ProgramForm formType="create" />;
+  const formData = useProgramFormData();
+
+  return (
+    <ProgramForm formType="create" formData={formData}>
+      <MemberTable
+        formType="create"
+        members={formData.members}
+        setMembers={formData.setMembers}
+      />
+    </ProgramForm>
+  );
 };
 export default ProgramCreateForm;

--- a/FE/src/components/programCreate/ProgramCreateForm.tsx
+++ b/FE/src/components/programCreate/ProgramCreateForm.tsx
@@ -1,0 +1,6 @@
+import ProgramForm from "../common/form/ProgramForm";
+
+const ProgramCreateForm = () => {
+  return <ProgramForm formType="create" />;
+};
+export default ProgramCreateForm;

--- a/FE/src/components/programEdit/EditMemberTableItemContainer.tsx
+++ b/FE/src/components/programEdit/EditMemberTableItemContainer.tsx
@@ -1,0 +1,4 @@
+const EditMemberTableItemContainer = () => {
+  return <h1>Edit Member Table Item Container</h1>;
+};
+export default EditMemberTableItemContainer;

--- a/FE/src/constants/ACTIVE_STATUS.ts
+++ b/FE/src/constants/ACTIVE_STATUS.ts
@@ -16,8 +16,8 @@ const TAB: ActiveStatusTab = {
 };
 
 const TAB_WITH_ALL: ActiveStatusWithAllTab = {
-  ...TAB,
   all: { type: "all", text: "All" },
+  ...TAB,
 };
 
 Object.freeze(TAB);

--- a/FE/src/constants/FORM_INFO.ts
+++ b/FE/src/constants/FORM_INFO.ts
@@ -1,0 +1,25 @@
+const PROGRAM = {
+  TITLE: {
+    id: "program_title",
+    type: "text",
+    label: "행사 이름",
+    placeholder: "행사 이름 입력",
+  },
+  DATE: {
+    id: "program_date",
+    type: "text",
+    label: "행사 일정",
+    placeholder: "XXXX-XX-XX",
+  },
+  CONTENT: {
+    id: "program_content",
+    type: "text",
+    label: "행사 내용",
+    placeholder: "행사 내용 입력",
+  },
+};
+
+const DEMAND_PREFIX = "[수요조사]";
+
+Object.freeze(PROGRAM);
+export default { PROGRAM, DEMAND_PREFIX };

--- a/FE/src/constants/FORM_INFO.ts
+++ b/FE/src/constants/FORM_INFO.ts
@@ -1,3 +1,4 @@
+import { FormType } from "./../types/form";
 const PROGRAM = {
   TITLE: {
     id: "program_title",
@@ -21,5 +22,15 @@ const PROGRAM = {
 
 const DEMAND_PREFIX = "[수요조사]";
 
+type SubmitText = {
+  [key in FormType]: string;
+};
+
+const SUBMIT_TEXT: SubmitText = {
+  create: "생성",
+  edit: "수정",
+};
+
 Object.freeze(PROGRAM);
-export default { PROGRAM, DEMAND_PREFIX };
+Object.freeze(SUBMIT_TEXT);
+export default { PROGRAM, DEMAND_PREFIX, SUBMIT_TEXT };

--- a/FE/src/hooks/useProgramFormData.ts
+++ b/FE/src/hooks/useProgramFormData.ts
@@ -1,0 +1,74 @@
+import { ProgramCategory, ProgramType } from "@/types/program";
+import { useEffect, useState } from "react";
+import { useGetProgramById } from "./query/useProgramQuery";
+
+interface ProgramFormDataState {
+  title: string;
+  deadLine: string;
+  type: ProgramType;
+  category: ProgramCategory;
+  content: string;
+  members: Set<number>;
+}
+
+interface ProgramFormDataAction {
+  setTitle: React.Dispatch<React.SetStateAction<string>>;
+  setDeadLine: React.Dispatch<React.SetStateAction<string>>;
+  setType: React.Dispatch<React.SetStateAction<ProgramType>>;
+  setCategory: React.Dispatch<React.SetStateAction<ProgramCategory>>;
+  setContent: React.Dispatch<React.SetStateAction<string>>;
+  setMembers: React.Dispatch<React.SetStateAction<Set<number>>>;
+  reset: () => void;
+}
+
+const initalState: ProgramFormDataState = {
+  title: "",
+  deadLine: new Date().getTime().toString(),
+  type: "notification",
+  category: "weekly",
+  content: "",
+  members: new Set<number>(),
+};
+
+export interface ProgramFormData
+  extends ProgramFormDataState,
+    ProgramFormDataAction {}
+
+const useProgramFormData = (
+  defaultData: ProgramFormDataState = initalState,
+) => {
+  const [title, setTitle] = useState<string>(defaultData.title);
+  const [deadLine, setDeadLine] = useState<string>(defaultData.deadLine);
+  const [type, setType] = useState<ProgramType>(defaultData.type);
+  const [category, setCategory] = useState<ProgramCategory>(
+    defaultData.category,
+  );
+  const [content, setContent] = useState<string>(defaultData.content);
+  const [members, setMembers] = useState<Set<number>>(defaultData.members);
+
+  const reset = () => {
+    setTitle(defaultData.title);
+    setDeadLine(defaultData.deadLine);
+    setType(defaultData.type);
+    setCategory(defaultData.category);
+    setContent(defaultData.content);
+    setMembers(defaultData.members);
+  };
+
+  return {
+    title,
+    setTitle,
+    deadLine,
+    setDeadLine,
+    type,
+    setType,
+    category,
+    setCategory,
+    content,
+    setContent,
+    members,
+    setMembers,
+    reset,
+  };
+};
+export default useProgramFormData;

--- a/FE/src/types/form.ts
+++ b/FE/src/types/form.ts
@@ -1,0 +1,1 @@
+export type FormType = "create" | "edit";

--- a/FE/src/utils/handleKeydown.ts
+++ b/FE/src/utils/handleKeydown.ts
@@ -1,0 +1,11 @@
+export const handleKeydown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+  if (e.key === "Tab") {
+    e.preventDefault();
+    const start = e.currentTarget.selectionStart;
+    const end = e.currentTarget.selectionEnd;
+    const target = e.currentTarget;
+    const value = target.value;
+    target.value = value.substring(0, start) + "  " + value.substring(end);
+    target.selectionStart = target.selectionEnd = start + 2;
+  }
+};


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련 있는 이슈 번호를 {#003}과 같이 기입해주세요.
해당 pull request를 merge할 때, 이슈를 close하려면
{closed #003}과 같이 기입해주세요. -->

closed #149

<img width="1407" alt="image" src="https://github.com/bada308/black-company/assets/71962076/671f74d4-6146-43ef-8213-ee60033bacb9">
<img width="1402" alt="image" src="https://github.com/bada308/black-company/assets/71962076/f361f41e-a2c1-48d8-9ab8-72f7cbb54f52">


## ✨ PR 내용
<!-- PR에 대한 내용을 설명해주세요. -->

### #149
```
- Calendar 컴포넌트 구현
- ProgramForm 컴포넌트 구현
- MemberTable 컴포넌트 구현
- program form 상태 관리 훅 구현
- 수요조사 체크박스 구현
```


## 주의 사항
브랜치 방향 꼭 확인하세요!!!!
